### PR TITLE
The Actuator now checks if the instances to change cap exist

### DIFF
--- a/bigsea-scaler/service/api/actuator/plugins/instance_locator.py
+++ b/bigsea-scaler/service/api/actuator/plugins/instance_locator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+from service.exceptions.kvm_exceptions import InstanceNotFoundException
 
 # TODO: documentation
 class Instance_Locator(object):
@@ -31,4 +31,4 @@ class Instance_Locator(object):
             if in_node == "0\n":
                 return compute_node
 
-        raise Instance_Not_Found_Exception(vm_id, "It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 
+        raise InstanceNotFoundException(vm_id, "It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 

--- a/bigsea-scaler/service/api/actuator/plugins/instance_locator.py
+++ b/bigsea-scaler/service/api/actuator/plugins/instance_locator.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+
 # TODO: documentation
 class Instance_Locator(object):
 
@@ -28,5 +30,5 @@ class Instance_Locator(object):
             in_node = self.ssh_utils.run_and_get_result(check_command, "root", compute_node, self.compute_nodes_key)
             if in_node == "0\n":
                 return compute_node
-        #FIXME: exception type
-        raise Exception("It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 
+
+        raise Instance_Not_Found_Exception(vm_id, "It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 

--- a/bigsea-scaler/service/api/actuator/plugins/instance_locator_tunnel.py
+++ b/bigsea-scaler/service/api/actuator/plugins/instance_locator_tunnel.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+
 class Instance_Locator_Tunnel:
     def __init__(self, ssh_utils, compute_nodes, compute_nodes_key):
         self.compute_nodes = compute_nodes
@@ -26,5 +28,5 @@ class Instance_Locator_Tunnel:
             in_node = self.ssh_utils.run_and_get_result_tunnel(check_command, "root", compute_node, self.compute_nodes_key)
             if in_node == "0\n":
                 return compute_node
-        #FIXME: exception type
-        raise Exception("It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 
+
+        raise Instance_Not_Found_Exception(vm_id, "It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 

--- a/bigsea-scaler/service/api/actuator/plugins/instance_locator_tunnel.py
+++ b/bigsea-scaler/service/api/actuator/plugins/instance_locator_tunnel.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+from service.exceptions.kvm_exceptions import InstanceNotFoundException
 
 class Instance_Locator_Tunnel:
     def __init__(self, ssh_utils, compute_nodes, compute_nodes_key):
@@ -29,4 +29,4 @@ class Instance_Locator_Tunnel:
             if in_node == "0\n":
                 return compute_node
 
-        raise Instance_Not_Found_Exception(vm_id, "It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 
+        raise InstanceNotFoundException(vm_id, "It was not possible to find the instance: command %s, ssh return value %s" % (check_command, in_node)) 

--- a/bigsea-scaler/service/api/actuator/plugins/kvm_actuator.py
+++ b/bigsea-scaler/service/api/actuator/plugins/kvm_actuator.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from service.api.actuator.actuator import Actuator
-from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+from service.exceptions.kvm_exceptions import InstanceNotFoundException
 
 # TODO: documentation
 
@@ -39,7 +39,7 @@ class KVM_Actuator(Actuator):
                 instance_location = self.instance_locator.locate(instance)
                 # Access a compute node and change cap
                 self.remote_kvm.change_vcpu_quota(instance_location, instance, int(vm_data[instance]))
-            except Instance_Not_Found_Exception:
+            except InstanceNotFoundException:
                 print "instance not found:%s" % (instance)
 
     # TODO: validation
@@ -54,7 +54,7 @@ class KVM_Actuator(Actuator):
         for vm_id in vms_ids:
             try:
                 return self.get_allocated_resources(vm_id)
-            except Instance_Not_Found_Exception:
+            except InstanceNotFoundException:
                 print "instance not found:%s" % (vm_id)
                 
         raise Exception("Could not get allocated resources")

--- a/bigsea-scaler/service/api/actuator/plugins/kvm_io_actuator.py
+++ b/bigsea-scaler/service/api/actuator/plugins/kvm_io_actuator.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from service.api.actuator.actuator import Actuator
-from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+from service.exceptions.kvm_exceptions import InstanceNotFoundException
 
 class KVM_IO_Actuator(Actuator):
     
@@ -36,7 +36,7 @@ class KVM_IO_Actuator(Actuator):
                 # Access a compute node and change cap
                 self.remote_kvm.change_vcpu_quota(instance_location, instance, int(vm_data[instance]))
                 self.remote_kvm.change_io_quota(instance_location, instance, int(vm_data[instance]))
-            except Instance_Not_Found_Exception:
+            except InstanceNotFoundException:
                 print "instance not found:%s" % (instance)
 
     # TODO: validation
@@ -51,7 +51,7 @@ class KVM_IO_Actuator(Actuator):
         for vm_id in vms_ids:
             try:
                 return self.get_allocated_resources(vm_id)
-            except Instance_Not_Found_Exception:
+            except InstanceNotFoundException:
                 print "instance not found:%s" % (vm_id)
                 
         raise Exception("Could not get allocated resources")

--- a/bigsea-scaler/service/api/actuator/plugins/kvm_io_actuator.py
+++ b/bigsea-scaler/service/api/actuator/plugins/kvm_io_actuator.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from service.api.actuator.actuator import Actuator
+from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
 
 class KVM_IO_Actuator(Actuator):
     
@@ -28,17 +29,15 @@ class KVM_IO_Actuator(Actuator):
     # TODO: validation
     # This method receives as argument a map {vm-id:cap}
     def adjust_resources(self, vm_data):
-        instances_locations = {}
-
-        # Discover vm_id - compute nodes map
         for instance in vm_data.keys():
-            # Access compute nodes to discover vms location
-            instances_locations[instance] = self.instance_locator.locate(instance)
-
-        for instance in vm_data.keys():
-            # Access a compute node and change cap
-            self.remote_kvm.change_vcpu_quota(instances_locations[instance], instance, int(vm_data[instance]))
-            self.remote_kvm.change_io_quota(instances_locations[instance], instance, int(vm_data[instance]))
+            try:
+                # Access compute nodes to discover vms location
+                instance_location = self.instance_locator.locate(instance)
+                # Access a compute node and change cap
+                self.remote_kvm.change_vcpu_quota(instance_location, instance, int(vm_data[instance]))
+                self.remote_kvm.change_io_quota(instance_location, instance, int(vm_data[instance]))
+            except Instance_Not_Found_Exception:
+                print "instance not found:%s" % (instance)
 
     # TODO: validation
     def get_allocated_resources(self, vm_id):
@@ -46,3 +45,13 @@ class KVM_IO_Actuator(Actuator):
         host = self.instance_locator.locate(vm_id)
         # Access a compute node and get amount of allocated resources
         return self.remote_kvm.get_allocated_resources(host, vm_id)
+    
+    # TODO: validation
+    def get_allocated_resources_to_cluster(self, vms_ids):
+        for vm_id in vms_ids:
+            try:
+                return self.get_allocated_resources(vm_id)
+            except Instance_Not_Found_Exception:
+                print "instance not found:%s" % (vm_id)
+                
+        raise Exception("Could not get allocated resources")

--- a/bigsea-scaler/service/api/controller/plugins/generic/generic_alarm.py
+++ b/bigsea-scaler/service/api/controller/plugins/generic/generic_alarm.py
@@ -88,7 +88,7 @@ class Generic_Alarm:
             self.last_action = "Getting allocated resources"
             
             # Get current CPU cap
-            cap = self.actuator.get_allocated_resources(instances[0])
+            cap = self.actuator.get_allocated_resources_to_cluster(instances)
             new_cap = max(cap - self.actuation_size, self.min_cap)
             
             self.logger.log("Scaling from %d to %d" % (cap, new_cap))
@@ -115,7 +115,7 @@ class Generic_Alarm:
             self.last_action = "Getting allocated resources"
             
             # Get current CPU cap
-            cap = self.actuator.get_allocated_resources(instances[0])
+            cap = self.actuator.get_allocated_resources_to_cluster(instances)
             new_cap = min(cap + self.actuation_size, self.max_cap)
             
             self.logger.log("Scaling from %d to %d" % (cap, new_cap))

--- a/bigsea-scaler/service/api/controller/plugins/proportional/proportional_alarm.py
+++ b/bigsea-scaler/service/api/controller/plugins/proportional/proportional_alarm.py
@@ -87,7 +87,7 @@ class Proportional_Alarm:
             self.last_action = "Getting allocated resources"
             
             # Get current CPU cap
-            cap = self.actuator.get_allocated_resources(instances[0])
+            cap = self.actuator.get_allocated_resources_to_cluster(instances)
             new_cap = self._decide_next_cap(cap, progress_error, self.heuristic_options)
             
             self.logger.log("Scaling from %d to %d" % (cap, new_cap))
@@ -114,7 +114,7 @@ class Proportional_Alarm:
             self.last_action = "Getting allocated resources"
             
             # Get current CPU cap
-            cap = self.actuator.get_allocated_resources(instances[0])
+            cap = self.actuator.get_allocated_resources_to_cluster(instances)
             new_cap = self._decide_next_cap(cap, progress_error, self.heuristic_options)
             
             self.logger.log("Scaling from %f to %f" % (cap, new_cap))

--- a/bigsea-scaler/service/api/controller/plugins/tendency/tendency_aware_proportional_alarm.py
+++ b/bigsea-scaler/service/api/controller/plugins/tendency/tendency_aware_proportional_alarm.py
@@ -85,7 +85,7 @@ class Tendency_Aware_Proportional_Alarm:
         self.last_action = "Getting allocated resources"
         
         # Get current CPU cap
-        cap = self.actuator.get_allocated_resources(instances[0])
+        cap = self.actuator.get_allocated_resources_to_cluster(instances)
         new_cap = max(cap - self.actuation_size, self.min_cap)
             
         self.logger.log("Scaling from %d to %d" % (cap, new_cap))
@@ -104,7 +104,7 @@ class Tendency_Aware_Proportional_Alarm:
         self.last_action = "Getting allocated resources"
         
         # Get current CPU cap
-        cap = self.actuator.get_allocated_resources(instances[0])
+        cap = self.actuator.get_allocated_resources_to_cluster(instances)
         new_cap = min(cap + self.actuation_size, self.max_cap)
         
         self.logger.log("Scaling from %d to %d" % (cap, new_cap))
@@ -125,7 +125,7 @@ class Tendency_Aware_Proportional_Alarm:
             difference = 0.0
             
         if difference < 0.0:
-            cap = self.actuator.get_allocated_resources(instances[0])
+            cap = self.actuator.get_allocated_resources_to_cluster(instances)
             new_cap = min(cap + self.actuation_size, self.max_cap)
             
             self.logger.log("Scaling from %d to %d" % (cap, new_cap))
@@ -136,7 +136,7 @@ class Tendency_Aware_Proportional_Alarm:
             
             self.cap = new_cap
         elif difference > 0.0:
-            cap = self.actuator.get_allocated_resources(instances[0])
+            cap = self.actuator.get_allocated_resources_to_cluster(instances)
             new_cap = max(cap - self.actuation_size, self.min_cap)
             
             self.logger.log("Scaling from %d to %d" % (cap, new_cap))

--- a/bigsea-scaler/service/exceptions/kvm_exceptions.py
+++ b/bigsea-scaler/service/exceptions/kvm_exceptions.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2017 LSD - UFCG.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Instance_Not_Found_Exception(Exception):
+
+    def __init__(self, instance_id=None, message=None):
+        self.instance_id = instance_id
+        self.message = message

--- a/bigsea-scaler/service/exceptions/kvm_exceptions.py
+++ b/bigsea-scaler/service/exceptions/kvm_exceptions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class Instance_Not_Found_Exception(Exception):
+class InstanceNotFoundException(Exception):
 
     def __init__(self, instance_id=None, message=None):
         self.instance_id = instance_id

--- a/bigsea-scaler/test/service/api/actuator/test_basic_actuator.py
+++ b/bigsea-scaler/test/service/api/actuator/test_basic_actuator.py
@@ -20,7 +20,7 @@ from utils.ssh_utils import SSH_Utils
 from service.api.actuator.plugins.kvm_actuator import KVM_Actuator
 from service.api.actuator.plugins.instance_locator import Instance_Locator
 from service.api.actuator.plugins.remote_kvm import Remote_KVM
-from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+from service.exceptions.kvm_exceptions import InstanceNotFoundException
 
 
 class Test_Basic_Actuator(unittest.TestCase):
@@ -48,7 +48,7 @@ class Test_Basic_Actuator(unittest.TestCase):
         if vm_id == self.vm_id1:
             return self.host_ip1
         else:
-            raise Instance_Not_Found_Exception(vm_id)
+            raise InstanceNotFoundException(vm_id)
 
     # TODO: more cases
     def test_prepare_environment_locates_and_acts_correctly_1_instance(self):

--- a/bigsea-scaler/test/service/api/actuator/test_instance_locator.py
+++ b/bigsea-scaler/test/service/api/actuator/test_instance_locator.py
@@ -17,7 +17,7 @@ import unittest
 from service.api.actuator.plugins.instance_locator import Instance_Locator
 from utils.ssh_utils import SSH_Utils
 from mock.mock import MagicMock
-from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
+from service.exceptions.kvm_exceptions import InstanceNotFoundException
 
 
 class Test_Instance_Locator(unittest.TestCase):
@@ -56,7 +56,7 @@ class Test_Instance_Locator(unittest.TestCase):
         self.ssh_utils.run_and_get_result = MagicMock()
         self.ssh_utils.run_and_get_result.side_effect = self.impossible_to_locate
         
-        self.assertRaises(Instance_Not_Found_Exception, self.instance_locator.locate, self.vm_id)
+        self.assertRaises(InstanceNotFoundException, self.instance_locator.locate, self.vm_id)
         
         self.ssh_utils.run_and_get_result.assert_any_call("virsh schedinfo %s > /dev/null 2> /dev/null ; echo $?" % (self.vm_id), self.user, 
                                                           self.compute_1, self.compute_nodes_key)

--- a/bigsea-scaler/test/service/api/actuator/test_instance_locator.py
+++ b/bigsea-scaler/test/service/api/actuator/test_instance_locator.py
@@ -17,6 +17,7 @@ import unittest
 from service.api.actuator.plugins.instance_locator import Instance_Locator
 from utils.ssh_utils import SSH_Utils
 from mock.mock import MagicMock
+from service.exceptions.kvm_exceptions import Instance_Not_Found_Exception
 
 
 class Test_Instance_Locator(unittest.TestCase):
@@ -55,7 +56,7 @@ class Test_Instance_Locator(unittest.TestCase):
         self.ssh_utils.run_and_get_result = MagicMock()
         self.ssh_utils.run_and_get_result.side_effect = self.impossible_to_locate
         
-        self.assertRaises(Exception, self.instance_locator.locate, self.vm_id)
+        self.assertRaises(Instance_Not_Found_Exception, self.instance_locator.locate, self.vm_id)
         
         self.ssh_utils.run_and_get_result.assert_any_call("virsh schedinfo %s > /dev/null 2> /dev/null ; echo $?" % (self.vm_id), self.user, 
                                                           self.compute_1, self.compute_nodes_key)

--- a/bigsea-scaler/test/service/api/controller/test_generic_alarm.py
+++ b/bigsea-scaler/test/service/api/controller/test_generic_alarm.py
@@ -41,6 +41,7 @@ class Test_Generic_Alarm(unittest.TestCase):
 
         self.instance_name_1 = "instance1"
         self.instance_name_2 = "instance2"
+        self.instances = [self.instance_name_1, self.instance_name_2]
 
         self.trigger_down = 30.0
         self.trigger_up = 10.0
@@ -98,7 +99,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -106,7 +107,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_2})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Remove resources
         new_cap = self.allocated_resources - self.actuation_size
         # The method tries to adjust the amount of resources
@@ -118,7 +119,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_0, self.instances)
 
@@ -126,7 +127,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_0})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         new_cap = self.allocated_resources + self.actuation_size
         # The method tries to adjust the amount of resources
@@ -138,7 +139,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_1, self.instances)
 
@@ -146,7 +147,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_1})
 
         # The method doesn't try to get the amount of allocated resources 
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         # The method doesn't try to adjust the amount of resources
         self.actuator.adjust_resources.assert_not_called()
 
@@ -164,7 +165,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_3, self.instances)
         
@@ -172,7 +173,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_3})
 
         # The method tries to get the amount of allocated resources 
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         new_cap = self.allocated_resources + self.actuation_size
         # The method tries to adjust the amount of resources
         self.actuator.adjust_resources.assert_called_once_with({self.instance_name_1:new_cap, self.instance_name_2:new_cap})
@@ -186,7 +187,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_4, self.instances)
 
@@ -194,7 +195,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_4})
 
         # The method tries to get the amount of allocated resources 
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         new_cap = self.allocated_resources - self.actuation_size
         # The method tries to adjust the amount of resources
         self.actuator.adjust_resources.assert_called_once_with({self.instance_name_1:new_cap, self.instance_name_2:new_cap})
@@ -212,7 +213,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_3, self.instances)
 
@@ -220,7 +221,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_3})
         
         # The method doesn't try to get the amount of allocated resources 
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         # The method doesn't try to adjust the amount of resources
         self.actuator.adjust_resources.assert_not_called()
         
@@ -233,7 +234,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_4, self.instances)
         
@@ -241,7 +242,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_4})
         
         # The method doesn't try to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         # The method doesn't try to adjust the amount of resources
         self.actuator.adjust_resources.assert_not_called()
 
@@ -253,7 +254,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_0, self.instances)
         
@@ -261,7 +262,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_0})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         new_cap = self.allocated_resources + self.actuation_size
         # The method tries to adjust the amount of resources
@@ -275,7 +276,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_0, self.instances)
         
@@ -283,7 +284,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_0})
 
         # The method doesn't try to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         # The method doesn't try to adjust the amount of resources
         self.actuator.adjust_resources.assert_not_called()
         
@@ -293,7 +294,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics_different_timestamps
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -301,7 +302,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_2})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Remove resources
         new_cap = self.allocated_resources - self.actuation_size
         # The method tries to adjust the amount of resources
@@ -316,7 +317,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics_different_timestamps
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -324,7 +325,7 @@ class Test_Generic_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(Generic_Alarm.ERROR_METRIC_NAME, {"application_id":self.application_id_2})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Remove resources
         new_cap = self.allocated_resources - self.actuation_size
         # The method tries to adjust the amount of resources

--- a/bigsea-scaler/test/service/api/controller/test_proportional_alarm.py
+++ b/bigsea-scaler/test/service/api/controller/test_proportional_alarm.py
@@ -41,6 +41,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
 
         self.instance_name_1 = "instance1"
         self.instance_name_2 = "instance2"
+        self.instances = [self.instance_name_1, self.instance_name_2]
 
         self.trigger_down = 30.0
         self.trigger_up = 10.0
@@ -110,7 +111,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -120,7 +121,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_2})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         
         # Remove resources
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
@@ -146,7 +147,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -156,7 +157,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_2})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         
         # Remove resources
         new_cap = self.min_cap
@@ -182,7 +183,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_0, self.instances)
 
@@ -192,7 +193,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_0})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
                             {"application_id":self.application_id_0})[1]
@@ -217,7 +218,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_0, self.instances)
 
@@ -227,7 +228,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_0})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         new_cap = self.max_cap
         # The method tries to adjust the amount of resources
@@ -248,7 +249,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_1, self.instances)
 
@@ -258,7 +259,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_1})
 
         # The method doesn't try to get the amount of allocated resources 
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         # The method doesn't try to adjust the amount of resources
         self.actuator.adjust_resources.assert_not_called()
 
@@ -275,7 +276,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_0, self.instances)
         
@@ -285,7 +286,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_0})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
                         {"application_id":self.application_id_0})[1]
@@ -302,7 +303,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metrics
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
         
         self.alarm.check_application_state(self.application_id_0, self.instances)
         
@@ -312,7 +313,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                 {"application_id":self.application_id_0})
 
         # The method doesn't try to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         # The method doesn't try to adjust the amount of resources
         self.actuator.adjust_resources.assert_not_called()
         
@@ -330,7 +331,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics_different_timestamps
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -340,7 +341,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_2})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Remove resources
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
                         {"application_id":self.application_id_2})[1]
@@ -358,7 +359,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics_different_timestamps
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -368,7 +369,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                         {"application_id":self.application_id_2})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Remove resources
         
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
@@ -396,7 +397,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -406,7 +407,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_2})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         
         # Remove resources
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
@@ -433,7 +434,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_2, self.instances)
 
@@ -443,7 +444,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                         {"application_id":self.application_id_2})
         
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         
         # Remove resources
         new_cap = self.min_cap
@@ -468,7 +469,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_0, self.instances)
 
@@ -478,7 +479,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                             {"application_id":self.application_id_0})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         error = self.metrics(Proportional_Alarm.ERROR_METRIC_NAME, 
                              {"application_id":self.application_id_0})[1]
@@ -504,7 +505,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.side_effect = self.metrics
 
         self.actuator.adjust_resources = MagicMock(return_value=None)
-        self.actuator.get_allocated_resources = MagicMock(return_value=self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value=self.allocated_resources)
 
         self.alarm.check_application_state(self.application_id_0, self.instances)
 
@@ -514,7 +515,7 @@ class Test_Proportional_Alarm(unittest.TestCase):
                     {"application_id":self.application_id_0})
 
         # The method tries to get the amount of allocated resources
-        self.actuator.get_allocated_resources.assert_called_once_with(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_called_once_with(self.instances)
         # Add resources
         new_cap = self.max_cap
         # The method tries to adjust the amount of resources

--- a/bigsea-scaler/test/service/api/controller/test_tendency_aware_proportional_alarm.py
+++ b/bigsea-scaler/test/service/api/controller/test_tendency_aware_proportional_alarm.py
@@ -41,6 +41,7 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
 
         self.instance_name_1 = "instance1"
         self.instance_name_2 = "instance2"
+        self.instances = [self.instance_name_1, self.instance_name_2]
 
         self.trigger_down = 30.0
         self.trigger_up = 10.0
@@ -73,9 +74,6 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
         timestamp = self.timestamps.pop(0)
         return timestamp, self.diff_values[application_id].pop(0)
 
-    def tearDown(self):
-        pass
-
     def test_alarm_base_case(self):
         # Base case
         # diff is null
@@ -85,27 +83,27 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
         # First call
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metric_values
-        self.actuator.get_allocated_resources = MagicMock(return_value = None)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value = None)
         self.actuator.adjust_resources = MagicMock(return_value = None)
         
         self.alarm.check_application_state(self.application_id_0, self.instances)
         
         self.metric_source.get_most_recent_value.assert_any_call(self.alarm.ERROR_METRIC_NAME, 
                                                                  {"application_id": self.application_id_0})
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         self.actuator.adjust_resources.assert_not_called()
         
         # Second call
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metric_values
-        self.actuator.get_allocated_resources = MagicMock(return_value = None)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value = None)
         self.actuator.adjust_resources = MagicMock(return_value = None)
         
         self.alarm.check_application_state(self.application_id_0, self.instances)
         
         self.metric_source.get_most_recent_value.assert_any_call(self.alarm.ERROR_METRIC_NAME, 
                                                                  {"application_id": self.application_id_0})
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         self.actuator.adjust_resources.assert_not_called()
     
     def test_case1(self):
@@ -114,20 +112,20 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
         # First call
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metric_values
-        self.actuator.get_allocated_resources = MagicMock(return_value = None)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value = None)
         self.actuator.adjust_resources = MagicMock(return_value = None)
         
         self.alarm.check_application_state(self.application_id_1, self.instances)
         
         self.metric_source.get_most_recent_value.assert_any_call(self.alarm.ERROR_METRIC_NAME, 
                                                                  {"application_id": self.application_id_1})
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         self.actuator.adjust_resources.assert_not_called()
         
         # Second call
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metric_values
-        self.actuator.get_allocated_resources = MagicMock(return_value = self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value = self.allocated_resources)
         self.actuator.adjust_resources = MagicMock(return_value = None)
         
         self.alarm.check_application_state(self.application_id_1, self.instances)
@@ -135,7 +133,7 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(self.alarm.ERROR_METRIC_NAME, 
                                                                  {"application_id": self.application_id_1})
         
-        self.actuator.get_allocated_resources.assert_any_call(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_any_call(self.instances)
         
         new_cap = self.allocated_resources + self.actuation_size
         self.actuator.adjust_resources.assert_any_call({self.instance_name_1:new_cap, self.instance_name_2:new_cap})
@@ -146,20 +144,20 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
         # First call
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metric_values
-        self.actuator.get_allocated_resources = MagicMock(return_value = None)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value = None)
         self.actuator.adjust_resources = MagicMock(return_value = None)
         
         self.alarm.check_application_state(self.application_id_2, self.instances)
         
         self.metric_source.get_most_recent_value.assert_any_call(self.alarm.ERROR_METRIC_NAME, 
                                                                  {"application_id": self.application_id_2})
-        self.actuator.get_allocated_resources.assert_not_called()
+        self.actuator.get_allocated_resources_to_cluster.assert_not_called()
         self.actuator.adjust_resources.assert_not_called()
         
         # Second call
         self.metric_source.get_most_recent_value = MagicMock()
         self.metric_source.get_most_recent_value.side_effect = self.metric_values
-        self.actuator.get_allocated_resources = MagicMock(return_value = self.allocated_resources)
+        self.actuator.get_allocated_resources_to_cluster = MagicMock(return_value = self.allocated_resources)
         self.actuator.adjust_resources = MagicMock(return_value = None)
         
         self.alarm.check_application_state(self.application_id_2, self.instances)
@@ -167,7 +165,7 @@ class Test_Tendency_Aware_Proportional_Alarm(unittest.TestCase):
         self.metric_source.get_most_recent_value.assert_any_call(self.alarm.ERROR_METRIC_NAME, 
                                                                  {"application_id": self.application_id_2})
         
-        self.actuator.get_allocated_resources.assert_any_call(self.instance_name_1)
+        self.actuator.get_allocated_resources_to_cluster.assert_any_call(self.instances)
         
         new_cap = self.allocated_resources - self.actuation_size
         self.actuator.adjust_resources.assert_any_call({self.instance_name_1:new_cap, self.instance_name_2:new_cap})


### PR DESCRIPTION
- Added a new exception, used when the instance locator cannot find the instance.
- KVM_Actuator catches the new type of exception.
- The alarms now try to get the amount of allocated resources using all the instances, not only the first one.